### PR TITLE
[Week3] 허기영 (0/2)

### DIFF
--- a/week3/hky035/42898.java
+++ b/week3/hky035/42898.java
@@ -1,0 +1,64 @@
+// 42898 등굣길
+class Solution {
+	int[][] map;
+	int[][] route;
+		
+	public int solution(int m, int n, int[][] puddles) {
+		map = new int[n][m];
+        route = new int[n][m];
+        
+        for(int i = 0 ; i < n ; i++){
+        	map[i][0]	= i;
+            route[i][0] = 1;
+        }
+        for(int i = 0 ; i < m ; i++){
+        	map[0][i]	= i;
+            route[0][i] = 1;
+        }
+        
+        for(int i = 0 ; i < puddles.length ; i++){
+        	int pY = puddles[i][0]-1;
+        	int pX = puddles[i][1]-1;
+        	
+            map[pX][pY] = Integer.MAX_VALUE;
+            if(pX == 0) {
+            	for(int j = pY ; j < m ; j++) {
+            		map[0][j] = Integer.MAX_VALUE;
+            		route[0][j] = 0;
+            	}
+            }
+            
+            if(pY == 0) {
+            	for(int j = pX ; j < n ; j++) {
+            		map[j][0] = Integer.MAX_VALUE;
+            		route[j][0] = 0;
+            	}
+            }
+        }
+    
+        
+        for(int i = 1 ; i < n ; i++){
+            for(int j = 1 ; j < m ; j++){
+                if(map[i][j] == Integer.MAX_VALUE){
+                    continue;
+                }
+                    
+//                map[i][j] = (map[i-1][j] < map[i][j-1]) ? map[i-1][j] : ((map[i-1][j] == map[i][j-1]) ? map[i-1][j] + map[i][j-1] : map[i][j-1]);
+                if (map[i-1][j] < map[i][j-1]) {
+                    map[i][j] = map[i-1][j] + 1;
+                    route[i][j] = route[i-1][j];
+                } else if (map[i-1][j] > map[i][j-1]) {
+                	map[i][j] = map[i][j-1] + 1;
+                	route[i][j] = route[i][j-1];
+                } else {
+                	map[i][j] = map[i][j-1] + 1;
+                	route[i][j] = route[i-1][j] + route[i][j-1];
+                }
+
+            }
+        }
+        
+		
+		return route[n-1][m-1] % 1000000007 ;
+	}
+}


### PR DESCRIPTION

## 1번. 등굣길

### 풀이
처음에는 dfs로 접근하였다. 그러나 테스트케이스는 통과하였으나 실행 결과는 지속적으로 실패하였다. 시간 초과도 많다는 것을 보았을 때 dfs로 접근이 아니라는 것을 알았다.   
그래서 dfs와 bfs와 같은 완전탐색이 아닌 그 전 결과를 **메모리제이션**을 통해서 값을 저장한 뒤 이를 상향식 설계로 문제를 해결해가는 DP 방법으로 문제를 풀어야한다는 것을 깨달았다. 또한, 문제에서 결과를 1,000,000,007로 나누는 것을 보아 가능한 경로수가 굉장히 많이 나올 수 있다는 것을 예측할 수 있다.   
   
DP를 적용하여 풀었을 때는 depth(이동 횟수)를 저장하는 `map` 배열과 경로 수를 저장하는 `route` 배열을 사용하였다.
![image](https://github.com/user-attachments/assets/dca448f1-46b6-40a2-a0b3-af76d73b233b)

다음과 같은 방식으로 행,열의 첫째 줄에 벽이 있을 경우 뒤로 있는 곳은 갈 수 없으므로 다 X 처리한다.(`Integer.MAX_VALUE`, `0`)   
이후 **위쪽에서 오는 값 vs 왼쪽에서 오는 값**을 비교하여 더 작은 경우가 있는 경로를 복사하며, 두 값이 같을 경우에는 `route`에는 두 경로를 합친다.   
   
다음과 같은 생각을 바탕으로 로직을 수행해봤는데 실패가 발생하였다. 해당 부분은 반례가 어떤 지 코드리뷰 때 토의해보고 싶다.

## 실행결과
![image](https://github.com/user-attachments/assets/a7c7f90c-5377-4d9f-9033-1c13bad9a9c3)


## 2번. 합승 택시 요금

### 풀이
우선 시간이 없어서 해당 방법은 풀지 못하였다.. (반성합니다. 해커톤이 너무 바빠서 그만...)
풀이 방법을 고려했을 때 Greedy를 사용하여 마치 Knapsack 문제처럼 `Math.min(해당 경로를 선택하는 경우, 해당 경로를 선택하지 않는 경우)`로 계속해서 min 값을 찾아가도록 한다.   
찾아나가며 경로를 저장하며, A와 B가 겹치는 경로가 있으면 해당 경로의 비용을 전체 합에서 제외한다.